### PR TITLE
Mimic custom attribute logic

### DIFF
--- a/dw/object/ExtensibleObject.js
+++ b/dw/object/ExtensibleObject.js
@@ -5,7 +5,7 @@ var ExtensibleObject = function(){};
 ExtensibleObject.prototype = new _super();
 
 ExtensibleObject.prototype.describe = function(){};
-ExtensibleObject.prototype.getCustom = function(){};
-ExtensibleObject.prototype.custom=null;
+ExtensibleObject.prototype.getCustom = function(){ return this.custom; };
+ExtensibleObject.prototype.custom={};
 
 module.exports = ExtensibleObject;


### PR DESCRIPTION
- getCustom() to return "custom“ object
- "custom" object should be an empty object instead of null

(Todo: Have a dw.object.customAttributes instance for ExtensibleObject.prototype.custom)