### PR TITLE
Add security notice for dependency-confusion advisory

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 > [GHSA-2xr6-47f3-hjmf](https://github.com/advisories/GHSA-2xr6-47f3-hjmf).
 >
 > - ✅ Install this project from GitHub only:
->   `"dw-api-mock": "git+ssh://github.com/SalesforceCommerceCloud/dw-api-mock.git"`
+>   `"@salesforce/dw-api-mock": "git+ssh://github.com/SalesforceCommerceCloud/dw-api-mock.git"`
 > - ❌ Never run `npm install dw-api-mock` or use a registry version like `"^1.0.0"` —
 >   that pulls the malicious package from npmjs.com.
 >
@@ -46,7 +46,7 @@ var proxyquire = require('proxyquire').noCallThru();
 chai.use(sinonChai);
 
 require.extensions['.ds'] = require.extensions['.js'];
-require('dw-api-mock/demandware-globals');
+require('@salesforce/dw-api-mock/demandware-globals');
 
 // add cartridges dir as module lookup location, the app-module-path package lets you do this nicely
 require('app-module-path').addPath(process.cwd() + '/cartridges');
@@ -83,7 +83,7 @@ Sample package.json
   "devDependencies": {
     "app-module-path": "^1.0.4",
     "chai": "^3.4.1",
-    "dw-api-mock": "git+ssh://github.com/SalesforceCommerceCloud/dw-api-mock.git",
+    "@salesforce/dw-api-mock": "git+ssh://github.com/SalesforceCommerceCloud/dw-api-mock.git",
     "istanbul": "^0.4.1",
     "mocha": "^2.3.4",
     "proxyquire": "^1.7.3",

--- a/README.md
+++ b/README.md
@@ -1,3 +1,18 @@
+> ## ⚠️ Security notice
+>
+> This GitHub repository is **not** malicious and is safe to use. However, a bad actor
+> published a **separate, malicious** package also named `dw-api-mock` to the public npm
+> registry. That package — not this repository — is the subject of GitHub Advisory
+> [GHSA-2xr6-47f3-hjmf](https://github.com/advisories/GHSA-2xr6-47f3-hjmf).
+>
+> - ✅ Install this project from GitHub only:
+>   `"dw-api-mock": "git+ssh://github.com/SalesforceCommerceCloud/dw-api-mock.git"`
+> - ❌ Never run `npm install dw-api-mock` or use a registry version like `"^1.0.0"` —
+>   that pulls the malicious package from npmjs.com.
+>
+> If your organization installed the npm package, notify your security team and rotate
+> secrets immediately from a clean machine. See [SECURITY.md](./SECURITY.md) for details.
+
 DW MOCK API
 ===========
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,54 @@
+# Security Policy
+
+## ⚠️ Important: `dw-api-mock` on the public npm registry is NOT this project
+
+This GitHub repository (`SalesforceCommerceCloud/dw-api-mock`) is a legitimate, safe
+mock of the Demandware Script API used for unit testing. **It is intended to be
+consumed directly from GitHub via a git URL — it was never published to the public
+npm registry by Salesforce.**
+
+A third party published a **malicious** package under the same name (`dw-api-mock`)
+to the public npm registry, exploiting the unclaimed name in a
+[dependency-confusion](https://cwe.mitre.org/data/definitions/506.html) attack. This
+is the subject of GitHub Security Advisory
+[GHSA-2xr6-47f3-hjmf](https://github.com/advisories/GHSA-2xr6-47f3-hjmf). **That
+advisory is scoped to the npm package — not to the source code in this repository.**
+
+### Safe usage
+
+Depend on this project from GitHub, never from the public npm registry:
+
+```json
+"devDependencies": {
+  "dw-api-mock": "git+ssh://github.com/SalesforceCommerceCloud/dw-api-mock.git"
+}
+```
+
+❌ Do **not** run `npm install dw-api-mock` and do **not** add a registry version such
+as `"dw-api-mock": "^1.0.0"` — either of those resolves the malicious package from
+npmjs.com.
+
+### If you installed the npm package
+
+If your environment ran `npm install dw-api-mock` and resolved it from the public npm
+registry, treat that environment as potentially compromised:
+
+1. Notify your security team.
+2. Rotate all secrets, credentials, and API keys **from a different, clean machine**.
+3. Remove the package. Because the malware may have granted an outside party control
+   of the machine, removal alone is not a guarantee of remediation.
+
+To confirm the source of your dependency, inspect your lockfile
+(`package-lock.json` / `yarn.lock`) and verify `dw-api-mock` resolves from the GitHub
+git URL rather than the npm registry.
+
+## Reporting a vulnerability
+
+If you believe you have found a security vulnerability in this repository, please
+report it privately rather than opening a public issue:
+
+- Use GitHub's [private vulnerability reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability)
+  ("Report a vulnerability" under the repository's **Security** tab), or
+- Contact the Salesforce Product Security team at <security@salesforce.com>.
+
+Please do not disclose the issue publicly until it has been reviewed and addressed.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -20,9 +20,12 @@ Depend on this project from GitHub, never from the public npm registry:
 
 ```json
 "devDependencies": {
-  "dw-api-mock": "git+ssh://github.com/SalesforceCommerceCloud/dw-api-mock.git"
+  "@salesforce/dw-api-mock": "git+ssh://github.com/SalesforceCommerceCloud/dw-api-mock.git"
 }
 ```
+
+The scoped `@salesforce/` name is owned by Salesforce on npmjs.com, so a third party
+cannot publish into it.
 
 ❌ Do **not** run `npm install dw-api-mock` and do **not** add a registry version such
 as `"dw-api-mock": "^1.0.0"` — either of those resolves the malicious package from

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/dw-api-mock",
   "description": "Demandware API mock making unit testing via rapunzel possible",
-  "version": "0.0.9",
+  "version": "1.0.0",
   "private": true,
   "license": "Demandware Community License",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "dw-api-mock",
+  "name": "@salesforce/dw-api-mock",
   "description": "Demandware API mock making unit testing via rapunzel possible",
   "version": "0.0.9",
   "private": true,


### PR DESCRIPTION
Add SECURITY.md and README banner clarifying this repo is safe and that the malicious npm package of the same name is unrelated.